### PR TITLE
Add systematic tests for escaped regex characters.

### DIFF
--- a/src/Task.ts
+++ b/src/Task.ts
@@ -867,7 +867,7 @@ export class Task {
      * Taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
      */
     private escapeRegExp(s: string) {
-        return s.replace(/([.*+?^${}(])/g, '\\$1');
+        return s.replace(/([.*+?^${}()])/g, '\\$1');
     }
 
     /*

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -867,7 +867,7 @@ export class Task {
      * Taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
      */
     private escapeRegExp(s: string) {
-        return s.replace(/([*])/g, '\\$1');
+        return s.replace(/([.*])/g, '\\$1');
     }
 
     /*

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -871,7 +871,7 @@ export class Task {
         Original line:
         return s.replace(/([.*+?^=!:${}()|[]\/\\])/g, '\\$1');
         */
-        return s.replace(/([.*+?^${}()|])/g, '\\$1');
+        return s.replace(/([.*+?^${}()|[])/g, '\\$1');
     }
 
     /*

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -867,10 +867,6 @@ export class Task {
      * Taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
      */
     private escapeRegExp(s: string) {
-        /*
-        Original line:
-        return s.replace(/([.*+?^=!:${}()|[]\/\\])/g, '\\$1');
-        */
         // NOTE: = is not escaped, as doing so gives error:
         //         Invalid regular expression: /(^|\s)hello\=world($|\s)/: Invalid escape
         // NOTE: ! is not escaped, as doing so gives error:

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -875,6 +875,8 @@ export class Task {
         //         Invalid regular expression: /(^|\s)hello\=world($|\s)/: Invalid escape
         // NOTE: ! is not escaped, as doing so gives error:
         //         Invalid regular expression: /(^|\s)hello\!world($|\s)/: Invalid escape
+        // NOTE: : is not escaped, as doing so gives error:
+        //         Invalid regular expression: /(^|\s)hello\:world($|\s)/: Invalid escape
         return s.replace(/([.*+?^${}()|[\]/\\])/g, '\\$1');
     }
 

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -871,6 +871,8 @@ export class Task {
         Original line:
         return s.replace(/([.*+?^=!:${}()|[]\/\\])/g, '\\$1');
         */
+        // NOTE: = is not escaped, as doing so gives error:
+        //         Invalid regular expression: /(^|\s)hello\=world($|\s)/: Invalid escape
         return s.replace(/([.*+?^${}()|[\]/\\])/g, '\\$1');
     }
 

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -867,7 +867,7 @@ export class Task {
      * Taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
      */
     private escapeRegExp(s: string) {
-        return s.replace(/([.*+?^$])/g, '\\$1');
+        return s.replace(/([.*+?^${])/g, '\\$1');
     }
 
     /*

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -867,7 +867,7 @@ export class Task {
      * Taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
      */
     private escapeRegExp(s: string) {
-        return s.replace(/([.*])/g, '\\$1');
+        return s.replace(/([.*+])/g, '\\$1');
     }
 
     /*

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -871,7 +871,7 @@ export class Task {
         Original line:
         return s.replace(/([.*+?^=!:${}()|[]\/\\])/g, '\\$1');
         */
-        return s.replace(/([.*+?^${}()|[\]\\])/g, '\\$1');
+        return s.replace(/([.*+?^${}()|[\]/\\])/g, '\\$1');
     }
 
     /*

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -867,7 +867,7 @@ export class Task {
      * Taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
      */
     private escapeRegExp(s: string) {
-        return s.replace(/([.*+])/g, '\\$1');
+        return s.replace(/([.*+?])/g, '\\$1');
     }
 
     /*

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -867,7 +867,7 @@ export class Task {
      * Taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
      */
     private escapeRegExp(s: string) {
-        return s.replace(/([.*+?^${])/g, '\\$1');
+        return s.replace(/([.*+?^${}])/g, '\\$1');
     }
 
     /*

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -867,7 +867,7 @@ export class Task {
      * Taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
      */
     private escapeRegExp(s: string) {
-        return s.replace(/([.*+?^])/g, '\\$1');
+        return s.replace(/([.*+?^$])/g, '\\$1');
     }
 
     /*

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -871,7 +871,7 @@ export class Task {
         Original line:
         return s.replace(/([.*+?^=!:${}()|[]\/\\])/g, '\\$1');
         */
-        return s.replace(/([.*+?^${}()|[])/g, '\\$1');
+        return s.replace(/([.*+?^${}()|[\]])/g, '\\$1');
     }
 
     /*

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -871,7 +871,7 @@ export class Task {
         Original line:
         return s.replace(/([.*+?^=!:${}()|[]\/\\])/g, '\\$1');
         */
-        return s.replace(/([.*+?^${}()])/g, '\\$1');
+        return s.replace(/([.*+?^${}()|])/g, '\\$1');
     }
 
     /*

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -873,6 +873,8 @@ export class Task {
         */
         // NOTE: = is not escaped, as doing so gives error:
         //         Invalid regular expression: /(^|\s)hello\=world($|\s)/: Invalid escape
+        // NOTE: ! is not escaped, as doing so gives error:
+        //         Invalid regular expression: /(^|\s)hello\!world($|\s)/: Invalid escape
         return s.replace(/([.*+?^${}()|[\]/\\])/g, '\\$1');
     }
 

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -867,7 +867,7 @@ export class Task {
      * Taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
      */
     private escapeRegExp(s: string) {
-        return s.replace(/([.*+?^${}])/g, '\\$1');
+        return s.replace(/([.*+?^${}(])/g, '\\$1');
     }
 
     /*

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -867,7 +867,7 @@ export class Task {
      * Taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
      */
     private escapeRegExp(s: string) {
-        return s.replace(/([.*+?^=!:${}()|[]\/\\])/g, '\\$1');
+        return s.replace(/([*])/g, '\\$1');
     }
 
     /*

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -871,7 +871,7 @@ export class Task {
         Original line:
         return s.replace(/([.*+?^=!:${}()|[]\/\\])/g, '\\$1');
         */
-        return s.replace(/([.*+?^${}()|[\]])/g, '\\$1');
+        return s.replace(/([.*+?^${}()|[\]\\])/g, '\\$1');
     }
 
     /*

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -867,6 +867,10 @@ export class Task {
      * Taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
      */
     private escapeRegExp(s: string) {
+        /*
+        Original line:
+        return s.replace(/([.*+?^=!:${}()|[]\/\\])/g, '\\$1');
+        */
         return s.replace(/([.*+?^${}()])/g, '\\$1');
     }
 

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -867,7 +867,7 @@ export class Task {
      * Taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
      */
     private escapeRegExp(s: string) {
-        return s.replace(/([.*+?])/g, '\\$1');
+        return s.replace(/([.*+?^])/g, '\\$1');
     }
 
     /*

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1057,6 +1057,9 @@ describe('check removal of the global filter exhaustively', () => {
         {
             globalFilter: ']',
         },
+        {
+            globalFilter: '\\',
+        },
     ])(
         'should parse global filter "$globalFilter" edge cases correctly',
         ({ globalFilter }) => {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1036,7 +1036,12 @@ describe('check removal of the global filter exhaustively', () => {
             // Invalid regular expression: /(^|\s)hello\=world($|\s)/: Invalid escape
             globalFilter: 'hello=world',
         },
-        // ! alone does not fail
+        {
+            // Failed attempt at creating a failing test for when ! was not escaped.
+            // When I make Task.escapeRegExp() escape !, I get:
+            // Invalid regular expression: /(^|\s)hello\!world($|\s)/: Invalid escape
+            globalFilter: 'hello!world',
+        },
         // : alone does not fail
         {
             globalFilter: '$',

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1042,7 +1042,12 @@ describe('check removal of the global filter exhaustively', () => {
             // Invalid regular expression: /(^|\s)hello\!world($|\s)/: Invalid escape
             globalFilter: 'hello!world',
         },
-        // : alone does not fail
+        {
+            // Failed attempt at creating a failing test for when : was not escaped.
+            // When I make Task.escapeRegExp() escape :, I get:
+            // Invalid regular expression: /(^|\s)hello\:world($|\s)/: Invalid escape
+            globalFilter: 'hello:world',
+        },
         {
             globalFilter: '$',
         },

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1045,6 +1045,9 @@ describe('check removal of the global filter exhaustively', () => {
         {
             globalFilter: '(',
         },
+        {
+            globalFilter: ')',
+        },
     ])(
         'should parse global filter "$globalFilter" edge cases correctly',
         ({ globalFilter }) => {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -991,6 +991,12 @@ describe('check removal of the global filter', () => {
             }
         },
     );
+});
+
+describe('check removal of the global filter exhaustively', () => {
+    type GlobalFilterRemoval = {
+        globalFilter: string;
+    };
 
     function checkDescription(
         markdownLine: string,
@@ -1006,16 +1012,12 @@ describe('check removal of the global filter', () => {
         );
     }
 
-    test.each<GlobalFilterRemovalExpectation>([
+    test.each<GlobalFilterRemoval>([
         {
             globalFilter: '#t',
-            markdownTask: 'UNUSED',
-            expectedDescription: 'UNUSED',
         },
         {
             globalFilter: '*',
-            markdownTask: 'UNUSED',
-            expectedDescription: 'UNUSED',
         },
     ])(
         'should parse global filter "$globalFilter" edge cases correctly',

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1051,6 +1051,9 @@ describe('check removal of the global filter exhaustively', () => {
         {
             globalFilter: '|',
         },
+        {
+            globalFilter: '[',
+        },
     ])(
         'should parse global filter "$globalFilter" edge cases correctly',
         ({ globalFilter }) => {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1024,6 +1024,9 @@ describe('check removal of the global filter exhaustively', () => {
         {
             globalFilter: '+',
         },
+        {
+            globalFilter: '?',
+        },
     ])(
         'should parse global filter "$globalFilter" edge cases correctly',
         ({ globalFilter }) => {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1017,6 +1017,9 @@ describe('check removal of the global filter exhaustively', () => {
             globalFilter: '#t',
         },
         {
+            globalFilter: '.',
+        },
+        {
             globalFilter: '*',
         },
     ])(

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1058,6 +1058,10 @@ describe('check removal of the global filter exhaustively', () => {
             globalFilter: ']',
         },
         {
+            // Failed attempt at creating a failing test for when / was not escaped
+            globalFilter: '///',
+        },
+        {
             globalFilter: '\\',
         },
     ])(

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1030,6 +1030,9 @@ describe('check removal of the global filter exhaustively', () => {
         {
             globalFilter: '^',
         },
+        {
+            globalFilter: '$',
+        },
     ])(
         'should parse global filter "$globalFilter" edge cases correctly',
         ({ globalFilter }) => {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1030,6 +1030,9 @@ describe('check removal of the global filter exhaustively', () => {
         {
             globalFilter: '^',
         },
+        // = alone does not fail
+        // ! alone does not fail
+        // : alone does not fail
         {
             globalFilter: '$',
         },

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1039,6 +1039,9 @@ describe('check removal of the global filter exhaustively', () => {
         {
             globalFilter: '{',
         },
+        {
+            globalFilter: '}',
+        },
     ])(
         'should parse global filter "$globalFilter" edge cases correctly',
         ({ globalFilter }) => {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1036,6 +1036,9 @@ describe('check removal of the global filter exhaustively', () => {
         {
             globalFilter: '$',
         },
+        {
+            globalFilter: '{',
+        },
     ])(
         'should parse global filter "$globalFilter" edge cases correctly',
         ({ globalFilter }) => {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1054,6 +1054,9 @@ describe('check removal of the global filter exhaustively', () => {
         {
             globalFilter: '[',
         },
+        {
+            globalFilter: ']',
+        },
     ])(
         'should parse global filter "$globalFilter" edge cases correctly',
         ({ globalFilter }) => {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1042,6 +1042,9 @@ describe('check removal of the global filter exhaustively', () => {
         {
             globalFilter: '}',
         },
+        {
+            globalFilter: '(',
+        },
     ])(
         'should parse global filter "$globalFilter" edge cases correctly',
         ({ globalFilter }) => {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1021,6 +1021,9 @@ describe('check removal of the global filter exhaustively', () => {
         {
             globalFilter: '*',
         },
+        {
+            globalFilter: '+',
+        },
     ])(
         'should parse global filter "$globalFilter" edge cases correctly',
         ({ globalFilter }) => {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1030,7 +1030,12 @@ describe('check removal of the global filter exhaustively', () => {
         {
             globalFilter: '^',
         },
-        // = alone does not fail
+        {
+            // Failed attempt at creating a failing test for when = was not escaped.
+            // When I make Task.escapeRegExp() escape =, I get:
+            // Invalid regular expression: /(^|\s)hello\=world($|\s)/: Invalid escape
+            globalFilter: 'hello=world',
+        },
         // ! alone does not fail
         // : alone does not fail
         {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1005,7 +1005,6 @@ describe('check removal of the global filter exhaustively', () => {
         const task = constructTaskFromLine(markdownLine);
 
         // Assert
-        console.log(markdownLine);
         expect(task).not.toBeNull();
         expect(task!.getDescriptionWithoutGlobalFilter()).toEqual(
             expectedDescription,

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1027,6 +1027,9 @@ describe('check removal of the global filter exhaustively', () => {
         {
             globalFilter: '?',
         },
+        {
+            globalFilter: '^',
+        },
     ])(
         'should parse global filter "$globalFilter" edge cases correctly',
         ({ globalFilter }) => {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -1048,6 +1048,9 @@ describe('check removal of the global filter exhaustively', () => {
         {
             globalFilter: ')',
         },
+        {
+            globalFilter: '|',
+        },
     ])(
         'should parse global filter "$globalFilter" edge cases correctly',
         ({ globalFilter }) => {

--- a/tests/Task.test.ts
+++ b/tests/Task.test.ts
@@ -962,6 +962,50 @@ describe('check removal of the global filter', () => {
             markdownTask: '- [ ] task with #t multiple global filters #t',
             expectedDescription: 'task with multiple global filters',
         },
+        {
+            globalFilter: '#t',
+            markdownTask: '- [ ] #t', // confirm behaviour when the description is empty
+            expectedDescription: '',
+        },
+
+        // Thorough use of global tag in all locations
+        {
+            globalFilter: '#t',
+            markdownTask: '- [ ] #t 1 #t 2 #t', // tag removed at beginning, middle and end
+            expectedDescription: '1 2',
+        },
+        {
+            globalFilter: '#t',
+            markdownTask: '- [ ] #tx 1 x#t #tx 2 x#t', // tag not removed if non-empty non-tag characters before or after it
+            expectedDescription: '#tx 1 x#t #tx 2 x#t',
+        },
+        {
+            globalFilter: '#t',
+            // tag not removed if non-empty characters before or after it.
+            // Include at least one occurrence of tag, so we don't pass by luck.
+            markdownTask: '- [ ] #t/x 1 x#t #t/x 2 #t #t/x',
+            expectedDescription: '#t/x 1 x#t #t/x 2 #t/x',
+        },
+
+        // Test with special character that should be escaped
+        {
+            // THIS CURRENTLY FAILS
+            // Expected: "1 2"
+            // Received: "* 1 * 2 *"
+            globalFilter: '*',
+            markdownTask: '- [ ] * 1 * 2 *', // tag removed at beginning, middle and end
+            expectedDescription: '1 2',
+        },
+        {
+            // THIS CURRENTLY FAILS
+            // Expected: "*x 1 x* *x 2 x*"
+            // Received: "*x 1 x* *x 2 * x*"
+            globalFilter: '*',
+            // tag not removed if non-empty characters before or after it.
+            // Include at least one occurrence of tag, so we don't pass by luck.
+            markdownTask: '- [ ] *x 1 x* *x 2 * x*',
+            expectedDescription: '*x 1 x* *x 2 x*',
+        },
     ])(
         'should parse "$markdownTask" and extract "$expectedDescription"',
         ({ globalFilter, markdownTask, expectedDescription }) => {


### PR DESCRIPTION
Hi,

To save you spending your time writing any new tests, here are the tests I added earlier of all the characters being escaped by `escapeRegExp()`, if you are happy to merge them in to your code.

I found that `=`, `!` and `:` gave errors when they were escaped, and wasn't able to write a test for which escaping them helped, and so I didn't re-added them to the regex.

I don't know what the solution is there.

Alternatively, if you could advise me on how they should be handled, I can always fix them after your PR is merged.

But please don't spend your time adding more test coverage independently.

